### PR TITLE
Remove language=en from Whisker call

### DIFF
--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -75,7 +75,7 @@ export class TranscriptionEngine {
         
         const options: RequestUrlParam = {
             method: 'POST',
-            url: `${this.settings.whisperASRUrl}/asr?task=transcribe&language=en&output=json`,
+            url: `${this.settings.whisperASRUrl}/asr?task=transcribe&output=json`,
             contentType: `multipart/form-data; boundary=----${boundary_string}`,
             body: request_body
         };


### PR DESCRIPTION
The parameter language=en forces tanslation into english of recordings which may be in another language.