### PR TITLE
Add ability to use Azure Speech Service

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
-		"date-fns": "^2.29.3"
+		"date-fns": "^2.29.3",
+    "microsoft-cognitiveservices-speech-sdk": "^1.31.0",
+		"webm-to-wav-converter": "1.1.0"
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -336,6 +336,7 @@ class TranscriptionSettingTab extends PluginSettingTab {
 			.setName('Language')
 			.setClass('azure-settings')
 			.addDropdown(dropdown => dropdown
+				.addOption('auto', 'Automatic')
 				.addOption('en-US', 'English (US)')
 				.addOption('uk-UA', 'Ukrainian')
 				.setValue(this.plugin.settings.azureLang)

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,10 @@ interface TranscriptionSettings {
 	debug: boolean;
 	dev: boolean;
 	swiftinkToken: string;
-	transcription_engine: string
+	transcription_engine: string;
+	azureKey: string;
+	azureRegion: string;
+	azureLang: string;
 }
 
 const DEFAULT_SETTINGS: TranscriptionSettings = {
@@ -24,7 +27,10 @@ const DEFAULT_SETTINGS: TranscriptionSettings = {
 	debug: false,
 	dev: false,
 	swiftinkToken: '',
-	transcription_engine: 'swiftink'
+	transcription_engine: 'swiftink',
+	azureKey: '',
+	azureRegion: "eastus",
+	azureLang: "en-US"
 }
 
 export default class Transcription extends Plugin {
@@ -195,10 +201,17 @@ class TranscriptionSettingTab extends PluginSettingTab {
 					if (value == 'swiftink') {
 						containerEl.findAll('.swiftink.settings').forEach((element) => { element.style.display = 'block'; });
 						containerEl.findAll('.whisper-asr-settings').forEach((element) => { element.style.display = 'none'; });
+						containerEl.findAll('.azure-settings').forEach((element) => { element.style.display = 'none'; });
 					}
 					else if (value == 'whisper_asr') {
 						containerEl.findAll('.swiftink.settings').forEach((element) => { element.style.display = 'none'; });
 						containerEl.findAll('.whisper-asr-settings').forEach((element) => { element.style.display = 'block'; });
+						containerEl.findAll('.azure-settings').forEach((element) => { element.style.display = 'none'; });
+					}
+					else if (value == 'azure_speech_service') {
+						containerEl.findAll('.swiftink.settings').forEach((element) => { element.style.display = 'none'; });
+						containerEl.findAll('.whisper-asr-settings').forEach((element) => { element.style.display = 'none'; });
+						containerEl.findAll('.azure-settings').forEach((element) => { element.style.display = 'block'; });
 					}
 				}));
 
@@ -292,6 +305,46 @@ class TranscriptionSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName('Azure Speech Service Settings')
+			.setClass('azure-settings')
+			.setHeading()
+
+		new Setting(containerEl)
+			.setName('Azure key')
+			.setDesc('Access key for Azure Speech Service')
+			.setClass('azure-settings')
+			.addText(text => text
+				.setValue(this.plugin.settings.azureKey)
+				.onChange(async (value) => {
+					this.plugin.settings.azureKey = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Azure region')
+			.setDesc('The location of your resource')
+			.setClass('azure-settings')
+			.addText(text => text
+				.setPlaceholder(DEFAULT_SETTINGS.azureRegion)
+				.setValue(this.plugin.settings.azureRegion)
+				.onChange(async (value) => {
+					this.plugin.settings.azureRegion = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Language')
+			.setClass('azure-settings')
+			.addDropdown(dropdown => dropdown
+				.addOption('en-US', 'English (US)')
+				.addOption('uk-UA', 'Ukrainian')
+				.setValue(this.plugin.settings.azureLang)
+				.onChange(async (value) => {
+					this.plugin.settings.azureLang = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName('Advanced Settings')
 			.setHeading()
 
@@ -322,10 +375,17 @@ class TranscriptionSettingTab extends PluginSettingTab {
 		if (this.plugin.settings.transcription_engine == 'swiftink') {
 			containerEl.findAll('.swiftink.settings').forEach((element) => { element.style.display = 'block'; });
 			containerEl.findAll('.whisper-asr-settings').forEach((element) => { element.style.display = 'none'; });
+			containerEl.findAll('.azure-settings').forEach((element) => { element.style.display = 'none'; });
 		}
 		else if (this.plugin.settings.transcription_engine == 'whisper_asr') {
 			containerEl.findAll('.swiftink.settings').forEach((element) => { element.style.display = 'none'; });
 			containerEl.findAll('.whisper-asr-settings').forEach((element) => { element.style.display = 'block'; });
+			containerEl.findAll('.azure-settings').forEach((element) => { element.style.display = 'none'; });
+		}
+		else if (this.plugin.settings.transcription_engine == 'azure_speech_service') {
+			containerEl.findAll('.swiftink.settings').forEach((element) => { element.style.display = 'none'; });
+			containerEl.findAll('.whisper-asr-settings').forEach((element) => { element.style.display = 'none'; });
+			containerEl.findAll('.azure-settings').forEach((element) => { element.style.display = 'block'; });
 		}
 
 		// If debug mode is off, hide the dev mode setting

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -198,8 +198,15 @@ export class TranscriptionEngine {
         // the recognizer itself
         const audioConfig = sdk.AudioConfig.fromWavFileInput(wavBuffer);
         const speechConfig = sdk.SpeechConfig.fromSubscription(subscriptionKey, serviceRegion);
-        speechConfig.speechRecognitionLanguage = this.settings.azureLang;        
-        const recognizer = new sdk.SpeechRecognizer(speechConfig, audioConfig);
+        const recognizer: sdk.SpeechRecognizer = (() => {
+            if (this.settings.azureLang === 'auto') {
+                const autoDetectLangConfig = sdk.AutoDetectSourceLanguageConfig.fromLanguages(["en-US", "uk-UA"]);
+                return sdk.SpeechRecognizer.FromConfig(speechConfig, autoDetectLangConfig, audioConfig);
+            } else {
+                speechConfig.speechRecognitionLanguage = this.settings.azureLang;        
+                return  new sdk.SpeechRecognizer(speechConfig, audioConfig);
+            }
+        })()
 
         return new Promise<string>((resolve, reject) => {
             let text = '';


### PR DESCRIPTION
This PR adds ability to use Azure Speech Service as a third option.
Notable changes: 
- adds 2 dependencies
- currently, settings allow to choose between en-US, uk-UA and automatic recognition (currently supports those 2 languages). Language support is easily extendable, just need to come up with a list.