### PR TITLE
Sequential Whisper ASR Server URL Fallback

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,7 @@ interface TranscriptionSettings {
     translate: boolean;
     language: string;
     verbosity: number;
-    whisperASRUrl: string;
+    whisperASRUrls: string;
     debug: boolean;
     transcriptionEngine: string;
     embedAdditionalFunctionality: boolean;
@@ -33,7 +33,7 @@ const DEFAULT_SETTINGS: TranscriptionSettings = {
     translate: false,
     language: "auto",
     verbosity: 1,
-    whisperASRUrl: "http://localhost:9000",
+    whisperASRUrls: "http://localhost:9000",
     debug: false,
     transcriptionEngine: "swiftink",
     embedAdditionalFunctionality: true,
@@ -422,17 +422,17 @@ class TranscriptionSettingTab extends PluginSettingTab {
             .setHeading();
 
         new Setting(containerEl)
-            .setName("Whisper ASR URL")
+            .setName("Whisper ASR URLs")
             .setDesc(
-                "The URL of the Whisper ASR server: https://github.com/ahmetoner/whisper-asr-webservice",
+                "The URL of the Whisper ASR server: https://github.com/ahmetoner/whisper-asr-webservice. Provide multiple URLs separated by semi-colons in case one is offline or not accessible. Tried in order.",
             )
             .setClass("whisper-asr-settings")
             .addText((text) =>
                 text
-                    .setPlaceholder(DEFAULT_SETTINGS.whisperASRUrl)
-                    .setValue(this.plugin.settings.whisperASRUrl)
+                    .setPlaceholder(DEFAULT_SETTINGS.whisperASRUrls)
+                    .setValue(this.plugin.settings.whisperASRUrls)
                     .onChange(async (value) => {
-                        this.plugin.settings.whisperASRUrl = value;
+                        this.plugin.settings.whisperASRUrls = value;
                         await this.plugin.saveSettings();
                     }),
             );

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -109,6 +109,8 @@ export class TranscriptionEngine {
                 body: request_body,
             };
 
+            console.log("Options:", options);
+
             try {
                 const response = await requestUrl(options);
                 if (this.settings.debug) console.log(response);

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -94,27 +94,33 @@ export class TranscriptionEngine {
         if (this.settings.language != "auto")
             args += `&language=${this.settings.language}`;
 
-        const url = `${this.settings.whisperASRUrl}/asr?${args}`;
-        console.log("URL:", url);
+        const urls = this.settings.whisperASRUrls
+            .split(";")
+            .filter(Boolean); // Remove empty strings
 
-        const options: RequestUrlParam = {
-            method: "POST",
-            url: url,
-            contentType: `multipart/form-data; boundary=----${boundary_string}`,
-            body: request_body,
-        };
-        console.log("Options:", options);
+        for (const baseUrl of urls) {
+            const url = `${baseUrl}/asr?${args}`;
+            console.log("Trying URL:", url);
 
-        return requestUrl(options)
-            .then(async (response) => {
+            const options: RequestUrlParam = {
+                method: "POST",
+                url: url,
+                contentType: `multipart/form-data; boundary=----${boundary_string}`,
+                body: request_body,
+            };
+
+            try {
+                const response = await requestUrl(options);
                 if (this.settings.debug) console.log(response);
                 if (typeof response.text === "string") return response.text;
                 else return response.json.text;
-            })
-            .catch((error) => {
-                if (this.settings.debug) console.error(error);
-                return Promise.reject(error);
-            });
+            } catch (error) {
+                if (this.settings.debug) console.error("Error with URL:", url, error);
+                // Don't return or throw yet, try the next URL
+            }
+        }
+        // If all URLs fail, reject the promise with a generic error or the last specific error caught
+        return Promise.reject("All Whisper ASR URLs failed");
     }
 
     async getTranscriptionSwiftink(file: TFile): Promise<string> {


### PR DESCRIPTION
Implements a feature allowing multiple Whisper ASR server URLs to be specified, separated by semi-colons. The system tries each URL in order, prioritizing the first accessible server. 

Ideal for users with a high-performance home lab server preferred when at home, with automatic fallback to a secondary server, like a less powerful laptop, when away. This update addresses the flexible server usage scenario described in issue #13, enhancing usability and access reliability.