### PR TITLE
Enhanced Timestamp Formatting and Custom Interval Grouping

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -4,6 +4,7 @@ import { Transcription } from "./main";
 interface TranscriptionSettings {
     timestamps: boolean;
     timestampFormat: string;
+    timestampInterval: string; // easier to store as a string and convert to number when needed
     translate: boolean;
     language: string;
     verbosity: number;
@@ -34,6 +35,7 @@ const IS_SWIFTINK = "swiftink";
 const DEFAULT_SETTINGS: TranscriptionSettings = {
     timestamps: false,
     timestampFormat: "auto",
+    timestampInterval: "0",
     translate: false,
     language: "auto",
     verbosity: 1,
@@ -303,6 +305,26 @@ class TranscriptionSettingTab extends PluginSettingTab {
             );
 
         new Setting(containerEl)
+            .setName("Timestamp interval")
+            .setDesc("The interval at which to add timestamps, in seconds.")
+            .setClass("depends-on-timestamps")
+            .addDropdown((dropdown) =>
+                dropdown
+                    .addOption("0", "Off")
+                    .addOption("5", "5")
+                    .addOption("10", "10")
+                    .addOption("15", "15")
+                    .addOption("20", "20")
+                    .addOption("30", "30")
+                    .addOption("60", "60")
+                    .setValue(this.plugin.settings.timestampInterval)
+                    .onChange(async (value) => {
+                        this.plugin.settings.timestampInterval = value;
+                        await this.plugin.saveSettings();
+                    }),
+            );
+
+        new Setting(containerEl)
             .setName("Swiftink Settings")
             .setClass("swiftink-settings")
             .setHeading();
@@ -488,7 +510,7 @@ class TranscriptionSettingTab extends PluginSettingTab {
 
         new Setting(containerEl)
             .setName("Word timestamps")
-            .setDesc("Include timestamps for each word, can get very verbose! Only works if timestamps are enabled.")
+            .setDesc("Include timestamps for each word, can get very verbose! Only works if timestamps are enabled. Overrides the timestamp interval.")
             .setClass("whisper-asr-settings")
             .setClass("depends-on-timestamps")
             .addToggle((toggle) =>

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -33,7 +33,7 @@ const IS_SWIFTINK = "swiftink";
 
 const DEFAULT_SETTINGS: TranscriptionSettings = {
     timestamps: false,
-    timestampFormat: "HH:mm:ss",
+    timestampFormat: "auto",
     translate: false,
     language: "auto",
     verbosity: 1,
@@ -286,11 +286,12 @@ class TranscriptionSettingTab extends PluginSettingTab {
         new Setting(containerEl)
             .setName("Timestamp format")
             .setDesc(
-                "Your choice of hours, minutes, and/or seconds in the timestamp",
+                "Your choice of hours, minutes, and/or seconds in the timestamp. Auto uses the shortest possible format.",
             )
             .setClass("depends-on-timestamps")
             .addDropdown((dropdown) =>
                 dropdown
+                    .addOption("auto", "Auto")
                     .addOption("HH:mm:ss", "HH:mm:ss")
                     .addOption("mm:ss", "mm:ss")
                     .addOption("ss", "ss")

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -129,7 +129,7 @@ export class TranscriptionEngine {
 
         let args = "output=json"; // always output json, so we can have the timestamps if we need them
         args += `&word_timestamps=true`; // always output word timestamps, so we can have the timestamps if we need them
-        const { translate, encode, vadFilter, timestamps, wordTimestamps, language, initialPrompt } = this.settings;
+        const { translate, encode, vadFilter, language, initialPrompt } = this.settings;
         if (translate) args += `&task=translate`;
         if (encode !== DEFAULT_SETTINGS.encode) args += `&encode=${encode}`;
         if (vadFilter !== DEFAULT_SETTINGS.vadFilter) args += `&vad_filter=${vadFilter}`;

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -44,22 +44,32 @@ export class TranscriptionEngine {
         segments: components["schemas"]["TimestampedTextSegment"][],
         timestampFormat: string,
     ): string {
+        let maxDuration = 0;
+
+        // Find the largest timestamp in the segments
+        segments.forEach(segment => {
+            maxDuration = Math.max(maxDuration, segment.end);
+        });
+
+        // Decide format based on maxDuration
+        const autoFormat = maxDuration < 3600 ? "mm:ss" : "HH:mm:ss";
+
         let transcription = "";
-        for (const segment of segments) {
+        segments.forEach(segment => {
             let start = new Date(segment.start * 1000);
             let end = new Date(segment.end * 1000);
 
-            start = new Date(
-                start.getTime() + start.getTimezoneOffset() * 60000,
-            );
+            start = new Date(start.getTime() + start.getTimezoneOffset() * 60000);
             end = new Date(end.getTime() + end.getTimezoneOffset() * 60000);
 
-            const start_formatted = format(start, timestampFormat);
-            const end_formatted = format(end, timestampFormat);
+            // Use autoFormat if timestampFormat is 'auto'
+            const formatToUse = timestampFormat === 'auto' ? autoFormat : timestampFormat;
+            const start_formatted = format(start, formatToUse);
+            const end_formatted = format(end, formatToUse);
 
             const segment_string = `${start_formatted} - ${end_formatted}: ${segment.text}\n`;
             transcription += segment_string;
-        }
+        });
         return transcription;
     }
 

--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -43,6 +43,7 @@ export class TranscriptionEngine {
     segmentsToTimestampedString(
         segments: components["schemas"]["TimestampedTextSegment"][],
         timestampFormat: string,
+        interval: number = 0 // in seconds, default is 0 which means no interval adjustment
     ): string {
         let maxDuration = 0;
 
@@ -55,21 +56,52 @@ export class TranscriptionEngine {
         const autoFormat = maxDuration < 3600 ? "mm:ss" : "HH:mm:ss";
 
         let transcription = "";
-        segments.forEach(segment => {
-            let start = new Date(segment.start * 1000);
-            let end = new Date(segment.end * 1000);
 
-            start = new Date(start.getTime() + start.getTimezoneOffset() * 60000);
-            end = new Date(end.getTime() + end.getTimezoneOffset() * 60000);
+        if (interval > 0) {
+            // Group segments based on interval
+            const groupedSegments: Record<string, { start: number, end: number, texts: string[] }> = {};
+            segments.forEach(segment => {
+                // Determine which interval the segment's start time falls into
+                const intervalStart = Math.floor(segment.start / interval) * interval;
+                if (!groupedSegments[intervalStart]) {
+                    groupedSegments[intervalStart] = {
+                        start: segment.start,
+                        end: segment.end,
+                        texts: [segment.text]
+                    };
+                } else {
+                    groupedSegments[intervalStart].end = Math.max(groupedSegments[intervalStart].end, segment.end);
+                    groupedSegments[intervalStart].texts.push(segment.text);
+                }
+            });
 
-            // Use autoFormat if timestampFormat is 'auto'
-            const formatToUse = timestampFormat === 'auto' ? autoFormat : timestampFormat;
-            const start_formatted = format(start, formatToUse);
-            const end_formatted = format(end, formatToUse);
+            // Format and append grouped segments
+            Object.values(groupedSegments).forEach(group => {
+                let start = new Date(group.start * 1000);
+                let end = new Date(group.end * 1000);
+                start = new Date(start.getTime() + start.getTimezoneOffset() * 60000);
+                end = new Date(end.getTime() + end.getTimezoneOffset() * 60000);
+                const formatToUse = timestampFormat === 'auto' ? autoFormat : timestampFormat;
+                const start_formatted = format(start, formatToUse);
+                const end_formatted = format(end, formatToUse);
+                const text = group.texts.join("").trim(); // spaces are already included in the segments
+                transcription += `${start_formatted} - ${end_formatted}: ${text}\n`;
+            });
+        } else {
+            // Default behavior: timestamp each segment individually
+            segments.forEach(segment => {
+                let start = new Date(segment.start * 1000);
+                let end = new Date(segment.end * 1000);
+                start = new Date(start.getTime() + start.getTimezoneOffset() * 60000);
+                end = new Date(end.getTime() + end.getTimezoneOffset() * 60000);
+                const formatToUse = timestampFormat === 'auto' ? autoFormat : timestampFormat;
+                const start_formatted = format(start, formatToUse);
+                const end_formatted = format(end, formatToUse);
+                const segment_string = `${start_formatted} - ${end_formatted}: ${segment.text.trim()}\n`;
+                transcription += segment_string;
+            });
+        }
 
-            const segment_string = `${start_formatted} - ${end_formatted}: ${segment.text}\n`;
-            transcription += segment_string;
-        });
         return transcription;
     }
 
@@ -102,11 +134,11 @@ export class TranscriptionEngine {
             await payloadGenerator(payload_data);
 
         let args = "output=json"; // always output json, so we can have the timestamps if we need them
+        args += `&word_timestamps=true`; // always output word timestamps, so we can have the timestamps if we need them
         const { translate, encode, vadFilter, timestamps, wordTimestamps, language, initialPrompt } = this.settings;
         if (translate) args += `&task=translate`;
         if (encode !== DEFAULT_SETTINGS.encode) args += `&encode=${encode}`;
         if (vadFilter !== DEFAULT_SETTINGS.vadFilter) args += `&vad_filter=${vadFilter}`;
-        if (timestamps && wordTimestamps !== DEFAULT_SETTINGS.wordTimestamps) args += `&word_timestamps=${wordTimestamps}`;
         if (language !== DEFAULT_SETTINGS.language) args += `&language=${language}`;
         if (initialPrompt) args += `&initial_prompt=${initialPrompt}`;
 
@@ -134,23 +166,24 @@ export class TranscriptionEngine {
                 const preprocessed = preprocessWhisperASRResponse(response.json);
                 if (this.settings.debug) console.log("Preprocessed response:", preprocessed);
 
-                if (
-                    this.settings.wordTimestamps
-                    && preprocessed.segments.some((segment: WhisperASRSegment) => segment.wordTimestamps)
-                ) {
-                    // Create segments for each word timestamp if word timestamps are available and enabled
-                    const wordSegments = preprocessed.segments
-                        .reduce((acc: components["schemas"]["TimestampedTextSegment"][], segment: WhisperASRSegment) => {
-                            if (segment.wordTimestamps) {
-                                acc.push(...segment.wordTimestamps.map(wordTimestamp => ({
-                                    start: wordTimestamp.start,
-                                    end: wordTimestamp.end,
-                                    text: wordTimestamp.word
-                                } as components["schemas"]["TimestampedTextSegment"])));
-                            }
-                            return acc;
-                        }, []);
+                // Create segments for each word timestamp if word timestamps are available
+                const wordSegments = preprocessed.segments
+                    .reduce((acc: components["schemas"]["TimestampedTextSegment"][], segment: WhisperASRSegment) => {
+                        if (segment.wordTimestamps) {
+                            acc.push(...segment.wordTimestamps.map(wordTimestamp => ({
+                                start: wordTimestamp.start,
+                                end: wordTimestamp.end,
+                                text: wordTimestamp.word
+                            } as components["schemas"]["TimestampedTextSegment"])));
+                        }
+                        return acc;
+                    }, []);
+
+                if (this.settings.wordTimestamps) {
                     return this.segmentsToTimestampedString(wordSegments, this.settings.timestampFormat);
+                } else if (parseInt(this.settings.timestampInterval)) {
+                    // Feed the function word segments with the interval
+                    return this.segmentsToTimestampedString(wordSegments, this.settings.timestampFormat, parseInt(this.settings.timestampInterval));
                 } else if (this.settings.timestamps) {
                     // Use existing segment-to-string functionality if only segment timestamps are needed
                     const segments = preprocessed.segments.map((segment: WhisperASRSegment) => ({
@@ -161,7 +194,10 @@ export class TranscriptionEngine {
                     return this.segmentsToTimestampedString(segments, this.settings.timestampFormat);
                 } else if (preprocessed.segments) {
                     // Concatenate all segments into a single string if no timestamps are required
-                    return preprocessed.segments.map((segment: WhisperASRSegment) => segment.text).join("\n");
+                    return preprocessed.segments
+                        .map((segment: WhisperASRSegment) => segment.text)
+                        .map(s => s.trim())
+                        .join("\n");
                 } else {
                     // Fallback to full text if no segments are there
                     return preprocessed.text;


### PR DESCRIPTION
In this PR, I'm rolling out two significant updates to our timestamp handling:

1. **Automatic Timestamp Formats**: I've introduced an `auto` timestamp format option, which is now the default setting. With this option selected, there's no need for manual selection between `HH:mm:ss`, `mm:ss`, or `ss`. The format adapts automatically: if the maximum segment timestamp exceeds 60 minutes, it displays in `HH:mm:ss`; for durations below 60 minutes, it switches to `mm:ss`. I chose not to switch to `ss` automatically because, from my perspective, it can seem unusual and be somewhat confusing. The option is still there for those that want it though.

2. **Custom Timestamp Intervals for Issue 45**: Tackling issue #45, I've implemented the ability to group segments by custom timestamp intervals, though this feature is initially turned off. This method intelligently calculates the start and end times for these groups. For instance, if you're working with a 15-second interval, but the actual speech is only from 00:04 to 00:13, the timestamp will smartly be shown as `00:04 - 00:13` for that group. However, it's important to highlight that the following group will proceed to consider the 00:15 to 00:30 interval, irrespective of the precise end time of the last segment from the preceding group. This feature is compatible with segments from both Whisper ASR and Swiftink, but it shines with word-level timestamps from Whisper ASR. This is because with smaller segments, there's a significantly lower chance of them crossing into another interval, making the grouping more precise and true to the spoken content.

In summary, these updates introduce a new 'Timestamp Interval' setting and involve a rewrite of the `segmentsToTimestampedString()` function. These changes enhance flexibility in timestamp formatting and segment grouping, offering users a more intuitive experience.