### PR TITLE
hotfix[whsiperASR]: Remove word_timestamp from getTranscriptionWhisperASR

### DIFF
--- a/src/transcribe.ts
+++ b/src/transcribe.ts
@@ -128,7 +128,6 @@ export class TranscriptionEngine {
             await payloadGenerator(payload_data);
 
         let args = "output=json"; // always output json, so we can have the timestamps if we need them
-        args += `&word_timestamps=true`; // always output word timestamps, so we can have the timestamps if we need them
         const { translate, encode, vadFilter, language, initialPrompt } = this.settings;
         if (translate) args += `&task=translate`;
         if (encode !== DEFAULT_SETTINGS.encode) args += `&encode=${encode}`;


### PR DESCRIPTION
Not supported by WhisperASR.  Fixes https://github.com/djmango/obsidian-transcription/issues/52

I'm not actually sure whether the newer ASR versions support this, we can always add back with something that parses the toggle setting properly. 