### PR TITLE
Fix for new Whisper ASR response format

### DIFF
--- a/src/types/whisper-asr.ts
+++ b/src/types/whisper-asr.ts
@@ -87,7 +87,12 @@ export type WhisperASRSegment = {
     /**
      * An array of word-level timestamps, providing detailed timing for each word spoken in the segment.
      */
-    wordTimestamps: WhisperASRWordTimestamp[] | null;
+    words: WhisperASRWordTimestamp[] | null;
+
+    /**
+     * The unique identifier for the segment.
+     */
+    id: number;
 };
 
 /**
@@ -116,7 +121,7 @@ export type WhisperASRWordTimestamp = {
      * The model's confidence in the accuracy of this word transcription.
      * @example 0.941351592540741
      */
-    confidence: number;
+    probability: number;
 };
 
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 /* Utility functions for Obsidian Transcript */
 import { App, FileSystemAdapter, getBlobArrayBuffer } from "obsidian";
-import { WhisperASRResponse, WhisperASRSegment } from "./types/whisper-asr";
+import { WhisperASRResponse, WhisperASRSegment, WhisperASRWordTimestamp } from "./types/whisper-asr";
 
 export const randomString = (length: number) => Array(length + 1).join((Math.random().toString(36) + '00000000000000000').slice(2, 18)).slice(0, length)
 export const getAllLinesFromFile = (cache: string) => cache.split(/\r?\n/)
@@ -74,15 +74,15 @@ export function preprocessWhisperASRResponse(rawResponse: any): WhisperASRRespon
                 avg_logprob: segment[7],
                 compression_ratio: segment[8],
                 no_speech_prob: segment[9],
-                wordTimestamps: null,
+                words: null,
             } as WhisperASRSegment;
             if (segment[10] !== null) { // easier to read than a ternary-destructured assignment
-                baseSegment.wordTimestamps = segment[10].map((wordTimestamp: any) => ({
+                baseSegment.words = segment[10].map((wordTimestamp: unknown[]) => ({
                     start: wordTimestamp[0],
                     end: wordTimestamp[1],
                     word: wordTimestamp[2],
-                    confidence: wordTimestamp[3],
-                }));
+                    probability: wordTimestamp[3],
+                } as WhisperASRWordTimestamp));
             }
             return baseSegment;
         })


### PR DESCRIPTION
# Work done
In a recent change, it seems as though Whisper ASR's JSON response format has changed, but only when `ASR_ENGINE=openai_whisper`. 

Thankfully, the part that we care about (`segments`) changed to respond in a format close to the format that we were already translating the old responses to, so this is a pretty small PR.

For more details, please see the [short writeup](https://github.com/djmango/obsidian-transcription/issues/52#issuecomment-2048449938) on the original issue.

Worth noting that when `ASR_ENGINE=faster_whisper`, it still responds in the old format. Because of this, we need to handle this format as well, which is done with a ternary.

**Note**: I opened an [issue](https://github.com/ahmetoner/whisper-asr-webservice/issues/209) on the Whisper ASR repo to fix this issue. If/when this gets done, it _should_ work here without issue.

fixes #52, replaces #54