### PR TITLE
fix: norwegian language should be no, not nb

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -115,7 +115,7 @@ const LANGUAGES = {
     MARATHI: "mr",
     MONGOLIAN: "mn",
     NEPALI: "ne",
-    NORWEGIAN: "nb",
+    NORWEGIAN: "no",
     OCCITAN: "oc",
     PANJABI: "pa",
     PERSIAN: "fa",


### PR DESCRIPTION
Based on ISO 639, I guess **Norwegian language should be `no`**, as `nb` (Norwegian bokmål, again from ISO 639) is not available in Whisper ASR languages, and service throws error like `ValueError: Unsupported language: nb`. If changing to `no`, Norwegian is working as expected (verified using local Whisper ASR)

(and thank you for this awesome plugin)