### PR TITLE
Fix timestamps option persistence bug

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -724,6 +724,10 @@ export default class Transcription extends Plugin {
 
     async saveSettings() {
         await this.saveData(this.settings);
+        // Update the transcription engine settings reference after saving
+        if (this.transcriptionEngine) {
+            this.transcriptionEngine.settings = this.settings;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #65 - Timestamps option persists after being toggled off

The issue was that the TranscriptionEngine held a reference to the settings object, but when settings were saved, the engine wasn't getting the updated reference. This caused timestamps to persist even after being toggled off.

The fix updates the TranscriptionEngine's settings reference in saveSettings() to ensure it always has the current settings.